### PR TITLE
Update CDN URL resolution

### DIFF
--- a/src/Cdn.py
+++ b/src/Cdn.py
@@ -34,7 +34,8 @@ def getModelInformationFromUrl(url: CdnUrl) -> ModelData:
 
 def getCdnUrlFromHash(hash: Hash) -> CdnUrl:
     st = 31
-    for i in range(0, 32):
+    hash_len = len(hash.hash)
+    for i in range(0, hash_len):
         st ^= ord(hash.hash[i])
     return CdnUrl(f"https://t{st % 8}.rbxcdn.com/{hash.hash}")
 


### PR DESCRIPTION
Roblox updated their hashes including extra data at the beginning that must be accounted for while resolving the URL. I've come across this myself in the form of "1DAY-..." However I have also seen ["30DAY-..."](https://devforum.roblox.com/t/roblox-cdn-how-to-work-out-the-hash/2731447) so it might be a good idea to use the length of the hash instead of a hard coded number.